### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -1,5 +1,8 @@
 name: Test CI Setup
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/1](https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/1)

To address the issue, we need to add a `permissions` block in the workflow YAML. The best way is to apply it at the workflow root, above `jobs:`, to ensure all jobs (current and future) inherit the minimal required privileges. In this scenario, the job does not push commits, create issues or comments, or interact with pull requests. The only thing it might need is the ability to check out code, which requires `contents: read`. Therefore, we add:
```yaml
permissions:
  contents: read
```
immediately after the `name: ...` and before or after the `on:` block (before `jobs:`). This requires no new imports or definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
