### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/2](https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/2)

To resolve this issue, add a minimal `permissions` block at the workflow level in `.github/workflows/ci.yml`. This will apply to all jobs in the workflow unless overridden. For CI and security tasks shown here, only `contents: read` is required, following the principle of least privilege. This block should be positioned immediately after the workflow `name:` and before the `on:` trigger, so the resulting YAML structure is correct and the permissions apply globally. No additional imports, methods, or definitions are required—just the YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
