### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/3](https://github.com/hsaito/regex-jgs-launcher/security/code-scanning/3)

To fix the issue, add an explicit `permissions:` block to the workflow, restricting the `GITHUB_TOKEN` to the minimal set of privileges required. As no steps in either job appear to require write permissions (all are read-only operations: IDE checkout, setup, audit, test, install, lint, etc.), it is appropriate to set the permissions to `contents: read` either at the workflow level (to cover all jobs) or individually for each job. The simplest and most robust approach is to add `permissions: contents: read` to the root of the workflow (after the `name:` line, before `on:`), which will apply to all jobs unless a job has an explicit override.

You only need to add the following lines near the top of the file:

```yaml
permissions:
  contents: read
```

No other code changes or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
