### PR TITLE
Lower VS Code engine requirement for broader compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+- Lowered the minimum VS Code engine requirement from 1.110.0 to 1.104.0 for broader compatibility.
+
 ## [0.2.14] - 2026-02-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-04-13
+
 ### Changed
 - Lowered the minimum VS Code engine requirement from 1.110.0 to 1.104.0 for broader compatibility.
 
@@ -214,7 +216,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Default keybindings and settings for paths, args, preArgs, and enable toggles.
 - Editor context and title menu entries when there is a selection.
 
-[Unreleased]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.9...HEAD
+[Unreleased]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.15...HEAD
+[0.2.15]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.14...v0.2.15
+[0.2.14]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.13...v0.2.14
+[0.2.13]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.12...v0.2.13
+[0.2.12]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.10...v0.2.12
+[0.2.10]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/hsaito/regex-jgs-launcher/compare/v0.2.6...v0.2.7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This VS Code extension lets you quickly launch RegexBuddy and RegexMagic from Just Great Software (JGsoft) directly from VS Code, passing the current selection, file, or folder context.
 
 **Publisher:** Hideki Saito  
-**Version:** 0.2.14  
+**Version:** 0.2.15  
 **License:** MIT
 
 ## Quick Start
@@ -87,6 +87,9 @@ This extension places the regex on the clipboard before launching the external t
 **RegexMagic usage note**: RegexMagic is designed to create regex patterns from sample text, not to edit existing regex patterns. If you want to edit an existing regex, use RegexBuddy instead.
 
 ## Release Notes
+
+- **0.2.15**:
+	- Lowered minimum supported VS Code version to 1.104.0 for broader compatibility
 
 - **0.2.14**:
 	- Maintenance release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "regex-jgs-launcher",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "regex-jgs-launcher",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",
-        "@types/vscode": "^1.110.0",
+        "@types/vscode": "^1.104.0",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
         "@vscode/test-cli": "^0.0.12",
@@ -21,7 +21,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.104.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/hsaito/regex-jgs-launcher.git"
   },
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.104.0"
   },
   "categories": [
     "Other"
@@ -236,7 +236,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "25.x",
-    "@types/vscode": "^1.110.0",
+    "@types/vscode": "^1.104.0",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "@vscode/test-cli": "^0.0.12",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/hsaito/regex-jgs-launcher/issues"
   },
   "icon": "logo.png",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request updates the extension to version 0.2.15, focusing on improving compatibility by lowering the minimum required VS Code version. Documentation and changelogs are updated accordingly.

Compatibility updates:

* Lowered the minimum supported VS Code engine version from 1.110.0 to 1.104.0 in both the `package.json` and development dependencies, allowing the extension to work with older VS Code versions. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R28) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L239-R239)

Documentation and release notes:

* Updated `README.md` and `CHANGELOG.md` to reflect the new version (0.2.15) and document the compatibility improvement. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R93) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R13) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL214-R224)
* Updated version number to 0.2.15 in `package.json`.